### PR TITLE
add deployment notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## Hubot Cloud Foundry helpers 
+## Hubot Cloud Foundry helpers
 
 Adds a number of (hopefully) helpful [Cloud Foundry](http://cloudfoundry.org)-related status commands to [hubot](http://hubot.github.com)
 
 #### Commands:
 
-Return [Cloud Foundry Core](http://core.cloudfoundry.com) information about the specified *API endpoint* 
-    
-    hubot cf-core <API endpoint>        
+Return [Cloud Foundry Core](http://core.cloudfoundry.com) information about the specified *API endpoint*
+
+    hubot cf-core <API endpoint>
 
 Return information about the status of cloudfoundry.com (via the [Status blog](http://status.cloudfoundry.com))
 
@@ -18,21 +18,22 @@ Return the most recent tweet from the [@cloudfoundry Twitter account](http://twi
 
 (more commands coming soon)
 
+#### Notifications:
+
+See the instructions at the top of [`notifications.coffee`](scripts/notifications.coffee) to
+
 #### Installation:
 
-**npm module method**
+1. In your deployed `hubot` directory:
 
-In your deployed ```hubot``` directory:
+        npm install hubot-cf --save
 
-    npm install hubot-cf
+1. Add an entry for `hubot-cf` to the `external-scripts.json` file (you may need to create this file, if it is not present):
 
-Add an entry for ```hubot-cf``` to the ```external-scripts.json``` file (you may need to create this file, if it is not present):
+        ["hubot-cf"]
 
-    ["hubot-cf"]
-    
-Add dependencies to your hubot ```package.json``` file (check the scripts for the ones required).
-
-Run hubot as normal, and the scripts should become available.
+1. Follow the configuration instructions at the top of [`notifications.coffee`](scripts/notifications.coffee).
+1. Run hubot as normal, and the scripts should become available.
 
 #### License:
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   },
   "dependencies": {
     "coffee-script": "~> 1.4.0",
+    "deep-extend": "^0.3.3",
     "mu2": "*",
     "request": "^2.55.0",
+    "simple-oauth2": "^0.2.1",
     "underscore": "*"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,13 +10,20 @@
   },
   "licenses": {
     "type": "Apache",
-    "url": "http://www.apache.org/licenses/LICENSE-2.0" },
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  },
   "dependencies": {
     "coffee-script": "~> 1.4.0",
     "mu2": "*",
+    "request": "^2.55.0",
     "underscore": "*"
   },
-  "keywords": [ "cloudfoundry", "cloud", "vcap", "status" ],
+  "keywords": [
+    "cloudfoundry",
+    "cloud",
+    "vcap",
+    "status"
+  ],
   "license": "Apache 2",
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "deep-extend": "^0.3.3",
     "mu2": "*",
     "request": "^2.55.0",
-    "simple-oauth2": "^0.2.1",
     "underscore": "*"
   },
   "keywords": [

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -1,9 +1,6 @@
 # Description:
 #   Sends notifications of Cloud Foundry activity.
 #
-# Dependencies:
-#   "<module name>": "<module version>"
-#
 # Configuration:
 #   HUBOT_CF_ACCESS_TOKEN
 #
@@ -26,6 +23,7 @@ childProcess.exec 'cf oauth-token | tail -n 1', (error, stdout, stderr) ->
   token = stdout.toString()
 
 
+# http://apidocs.cloudfoundry.org/205/events/list_app_update_events.html
 getRequestOpts = (since) ->
   sinceStr = since.toISOString()
   {
@@ -71,7 +69,7 @@ module.exports = (robot) ->
   setInterval(->
     getDeployEntities lastCheckedAt, (error, entities) ->
       for entity in entities
-        # TODO room mappings
+        # TODO map to particular rooms based on organization_guid
         envelope = {room: 'cf-notifications'}
         robot.send(envelope, "#{entity.actor_name} is deploying #{entity.actee_name}")
 

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -12,7 +12,6 @@
 #   afeld
 
 childProcess = require('child_process')
-request = require('request')
 client = require('../src/client')
 
 

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -33,7 +33,6 @@ getRequestOpts = (since) ->
       Authorization: token
     useQuerystring: true
     qs:
-      'order-direction': 'desc'
       q: [
         "timestamp>#{sinceStr}"
         'type:audit.app.update'

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -30,7 +30,7 @@ getRequestOpts = (since) ->
 
 getUpdateEvents = (since, callback) ->
   opts = getRequestOpts(since)
-  client.get opts, (error, response, data) ->
+  client.call opts, (error, response, data) ->
     callback(error, data.resources)
 
 

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -8,20 +8,24 @@
 #   HUBOT_CF_ACCESS_TOKEN
 #
 # Notes:
-#   Get the access token via `cf oauth-token` from the CLI. Leave off the 'bearer'.
+#   Get the access token via `cf oauth-token` from the CLI, including the 'bearer'.
 #
 # Author:
 #   afeld
 
+childProcess = require('child_process')
 request = require('request')
 
-token = process.env.HUBOT_CF_ACCESS_TOKEN || throw new Error("Please set HUBOT_CF_ACCESS_TOKEN.")
+# token = process.env.HUBOT_CF_ACCESS_TOKEN || throw new Error("Please set HUBOT_CF_ACCESS_TOKEN.")
+
+# hack to get the up-to-date token - requires Node 0.12+
+token = childProcess.execSync('cf oauth-token | tail -n 1').toString()
 
 opts = {
   url: 'http://api.cf.18f.us/v2/events'
   json: true
   headers:
-    Authorization: "bearer #{token}"
+    Authorization: token
   qs:
     'order-direction': 'desc'
 }

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -1,0 +1,33 @@
+# Description:
+#   Sends notifications of Cloud Foundry activity.
+#
+# Dependencies:
+#   "<module name>": "<module version>"
+#
+# Configuration:
+#   HUBOT_CF_ACCESS_TOKEN
+#
+# Notes:
+#   Get the access token via `cf oauth-token` from the CLI. Leave off the 'bearer'.
+#
+# Author:
+#   afeld
+
+request = require('request')
+
+token = process.env.HUBOT_CF_ACCESS_TOKEN || throw new Error("Please set HUBOT_CF_ACCESS_TOKEN.")
+
+opts = {
+  url: 'http://api.cf.18f.us/v2/events'
+  json: true
+  headers:
+    Authorization: "bearer #{token}"
+  qs:
+    'order-direction': 'desc'
+}
+
+request opts, (error, response, body) ->
+  console.log(body)
+
+
+# module.exports = (robot) ->

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -25,8 +25,7 @@ token = childProcess.execSync('cf oauth-token | tail -n 1').toString()
 
 getRequestOpts = (since) ->
   sinceStr = since.toISOString()
-
-  opts = {
+  {
     url: 'http://api.cf.18f.us/v2/events'
     json: true
     headers:
@@ -44,16 +43,15 @@ getRequestOpts = (since) ->
 getDeployEvents = (since, callback) ->
   opts = getRequestOpts(since)
   request opts, (error, response, data) ->
-    callback(error, data)
+    callback(error, data.resources)
 
 
 printDeployEvents = (since, callback) ->
-  getDeployEvents since, (error, data) ->
-    for event in data.resources
+  getDeployEvents since, (error, events) ->
+    for event in events
       entity = event.entity
-      # A mediocre proxy for an existin app being `push`ed, though it has false positives like new instances starting.
-      # TODO check for a previous 'STOPPED'
-      if entity?.metadata?.request?.state is 'STARTED'
+      # A mediocre proxy for an existing app being `push`ed, since it has false positives like new instances starting.
+      if entity.metadata?.request?.state is 'STARTED'
         console.log("#{entity.actor_name} is deploying #{entity.actee_name}")
 
 

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -2,11 +2,16 @@
 #   Sends notifications of Cloud Foundry activity.
 #
 # Configuration:
-#   HUBOT_CF_CLIENT_ID
-#   HUBOT_CF_CLIENT_SECRET
+#   HUBOT_CF_USER
+#   HUBOT_CF_PASS
 #
 # Notes:
-#   Create the client credentials via `uaac client add hubot-cf --scope uaa.none`
+#   Create the client credentials via:
+#
+#     cf create-user hubot-cf-listener <password>
+#     cf set-org-role hubot-cf-listener <org> OrgAuditor
+#
+#   then set HUBOT_CF_USER and HUBOT_CF_PASS.
 #
 # Author:
 #   afeld
@@ -62,5 +67,13 @@ notifyForDeploys = (robot) ->
   , 5000)
 
 
-module.exports = (robot) ->
-  notifyForDeploys(robot)
+
+# check if run directly, for testing
+if require.main is module
+  since = new Date(2014)
+  getDeployEntities since, (error, entities) ->
+    console.log('error:', error)
+    console.log(entities)
+else
+  module.exports = (robot) ->
+    notifyForDeploys(robot)

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -16,6 +16,7 @@
 childProcess = require('child_process')
 request = require('request')
 
+
 # token = process.env.HUBOT_CF_ACCESS_TOKEN || throw new Error("Please set HUBOT_CF_ACCESS_TOKEN.")
 
 # hack to get the up-to-date token - requires Node 0.12+
@@ -50,8 +51,10 @@ printDeployEvents = (since, callback) ->
   getDeployEvents since, (error, data) ->
     for event in data.resources
       entity = event.entity
-      deployedAt = new Date(entity.timestamp)
-      console.log("#{entity.actor_name} deployed #{entity.actee_name} at #{deployedAt}")
+      # A mediocre proxy for an existin app being `push`ed, though it has false positives like new instances starting.
+      # TODO check for a previous 'STOPPED'
+      if entity?.metadata?.request?.state is 'STARTED'
+        console.log("#{entity.actor_name} is deploying #{entity.actee_name}")
 
 
 # poll for deployment events

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -13,22 +13,14 @@
 
 childProcess = require('child_process')
 request = require('request')
-credentials = require('../src/credentials')
-
-credentials.fetchToken()
+client = require('../src/client')
 
 
 # http://apidocs.cloudfoundry.org/205/events/list_app_update_events.html
 getRequestOpts = (since) ->
-  token = credentials.getToken()
   sinceStr = since.toISOString()
-
   {
-    url: 'http://api.cf.18f.us/v2/events'
-    json: true
-    headers:
-      Authorization: token
-    useQuerystring: true
+    path: '/v2/events'
     qs:
       q: [
         "timestamp>#{sinceStr}"
@@ -39,7 +31,7 @@ getRequestOpts = (since) ->
 
 getUpdateEvents = (since, callback) ->
   opts = getRequestOpts(since)
-  request opts, (error, response, data) ->
+  client.get opts, (error, response, data) ->
     callback(error, data.resources)
 
 

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -4,6 +4,8 @@
 # Configuration:
 #   HUBOT_CF_USER
 #   HUBOT_CF_PASS
+#   HUBOT_CF_API_ORIGIN
+#   HUBOT_CF_UAA_ORIGIN
 #
 # Notes:
 #   Create the client credentials via:

--- a/scripts/notifications.coffee
+++ b/scripts/notifications.coffee
@@ -28,10 +28,14 @@ opts = {
     Authorization: token
   qs:
     'order-direction': 'desc'
+    q: 'type:audit.app.update'
 }
 
-request opts, (error, response, body) ->
-  console.log(body)
+request opts, (error, response, data) ->
+  for event in data.resources
+    entity = event.entity
+    deployedAt = new Date(entity.timestamp)
+    console.log("#{entity.actor_name} deployed #{entity.actee_name} at #{deployedAt}")
 
 
 # module.exports = (robot) ->

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -19,7 +19,7 @@ module.exports = {
       useQuerystring: true
     }
 
-  get: (opts, callback) ->
+  call: (opts, callback) ->
     credentials.fetchTokenObj (token) =>
       allOpts = @generalRequestOpts(token.token.access_token)
       deepExtend(allOpts, opts)

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,0 +1,32 @@
+deepExtend = require('deep-extend')
+credentials = require('../src/credentials')
+
+
+credentials.fetchToken()
+# TODO make configurable
+apiOrigin = 'http://api.cf.18f.us'
+
+
+module.exports = {
+  resolveUrl: (path) ->
+    apiOrigin + path
+
+  generalRequestOpts: ->
+    token = credentials.getToken()
+    {
+      json: true
+      headers:
+        Authorization: token
+      useQuerystring: true
+    }
+
+  get: (opts, callback) ->
+    allOpts = generalRequestOpts()
+    deepExtend(allOpts, opts)
+
+    if allOpts.path
+      allOpts.url = @resolveUrl(opts.path)
+      appOpts.path = null
+
+    request(allOpts, callback)
+}

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -21,7 +21,7 @@ module.exports = {
 
   call: (opts, callback) ->
     credentials.fetchTokenObj (token) =>
-      allOpts = @generalRequestOpts(token.token.access_token)
+      allOpts = @generalRequestOpts(token.access_token)
       deepExtend(allOpts, opts)
 
       if allOpts.path

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -3,7 +3,6 @@ request = require('request')
 credentials = require('../src/credentials')
 
 
-credentials.fetchToken()
 # TODO make configurable
 apiOrigin = 'http://api.cf.18f.us'
 
@@ -12,22 +11,22 @@ module.exports = {
   resolveUrl: (path) ->
     apiOrigin + path
 
-  generalRequestOpts: ->
-    token = credentials.getToken()
+  generalRequestOpts: (accessToken) ->
     {
       json: true
       headers:
-        Authorization: token
+        Authorization: "Bearer #{accessToken}"
       useQuerystring: true
     }
 
   get: (opts, callback) ->
-    allOpts = @generalRequestOpts()
-    deepExtend(allOpts, opts)
+    credentials.fetchTokenObj (token) =>
+      allOpts = @generalRequestOpts(token.token.access_token)
+      deepExtend(allOpts, opts)
 
-    if allOpts.path
-      allOpts.url = @resolveUrl(opts.path)
-      allOpts.path = null
+      if allOpts.path
+        allOpts.url = @resolveUrl(opts.path)
+        delete allOpts.path
 
-    request(allOpts, callback)
+      request(allOpts, callback)
 }

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,4 +1,5 @@
 deepExtend = require('deep-extend')
+request = require('request')
 credentials = require('../src/credentials')
 
 
@@ -21,12 +22,12 @@ module.exports = {
     }
 
   get: (opts, callback) ->
-    allOpts = generalRequestOpts()
+    allOpts = @generalRequestOpts()
     deepExtend(allOpts, opts)
 
     if allOpts.path
       allOpts.url = @resolveUrl(opts.path)
-      appOpts.path = null
+      allOpts.path = null
 
     request(allOpts, callback)
 }

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -3,13 +3,12 @@ request = require('request')
 credentials = require('../src/credentials')
 
 
-# TODO make configurable
-apiOrigin = 'http://api.cf.18f.us'
-
-
 module.exports = {
+  apiOrigin: ->
+    process.env.HUBOT_CF_API_ORIGIN || throw new Error("Please set HUBOT_CF_API_ORIGIN.")
+
   resolveUrl: (path) ->
-    apiOrigin + path
+    @apiOrigin() + path
 
   generalRequestOpts: (accessToken) ->
     {

--- a/src/credentials.coffee
+++ b/src/credentials.coffee
@@ -1,0 +1,41 @@
+# https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#access-token-administration-apis
+# http://andreareginato.github.io/simple-oauth2/#getting-started/client-credentials-flow
+
+token = null
+
+module.exports = {
+  clientId: ->
+    process.env.HUBOT_CF_CLIENT_ID || throw new Error("Please set HUBOT_CF_CLIENT_ID.")
+
+  clientSecret: ->
+    process.env.HUBOT_CF_CLIENT_SECRET || throw new Error("Please set HUBOT_CF_CLIENT_SECRET.")
+
+  site: ->
+    # TODO make configurable
+    'https://login.cf.18f.us'
+
+  credentials: ->
+    {
+      clientID: @clientId()
+      clientSecret: @clientSecret()
+      site: @site()
+      # TODO set endpoints
+    }
+
+  oauth2Instance: ->
+    creds = @credentials()
+    require('simple-oauth2')(creds)
+
+  # TODO use promises
+  fetchToken: ->
+    oauth2 = @oauth2Instance()
+    oauth2.client.getToken({}, saveToken)
+
+  getToken: ->
+    token
+
+  saveToken: (error, result) ->
+    if error
+      console.log('Access Token Error', error.message)
+    token = oauth2.accessToken.create(result)
+}

--- a/src/credentials.coffee
+++ b/src/credentials.coffee
@@ -12,7 +12,7 @@ module.exports = {
 
   site: ->
     # TODO make configurable
-    'https://login.cf.18f.us'
+    'http://login.cf.18f.us'
 
   credentials: ->
     {
@@ -29,7 +29,7 @@ module.exports = {
   # TODO use promises
   fetchToken: ->
     oauth2 = @oauth2Instance()
-    oauth2.client.getToken({}, saveToken)
+    oauth2.client.getToken({}, @saveToken.bind(@))
 
   getToken: ->
     token
@@ -37,5 +37,8 @@ module.exports = {
   saveToken: (error, result) ->
     if error
       console.log('Access Token Error', error.message)
-    token = oauth2.accessToken.create(result)
+    else
+      # TODO don't re-create
+      oauth2 = @oauth2Instance()
+      token = oauth2.accessToken.create(result)
 }

--- a/src/credentials.coffee
+++ b/src/credentials.coffee
@@ -9,16 +9,13 @@ module.exports = {
   password: ->
     process.env.HUBOT_CF_PASS || throw new Error("Please set HUBOT_CF_PASS.")
 
-  site: ->
-    # don't break when encountering self-signed certs
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-    # TODO make configurable
-    'https://uaa.cf.18f.us'
+  uaaOrigin: ->
+    process.env.HUBOT_CF_UAA_ORIGIN || throw new Error("Please set HUBOT_CF_UAA_ORIGIN.")
 
   requestOpts: ->
     # https://gist.github.com/ozzyjohnson/6ae51e3fdebc8a839751
     {
-      url: @site() + '/oauth/token'
+      url: @uaaOrigin() + '/oauth/token'
       method: 'POST'
       json: true
       headers:


### PR DESCRIPTION
Hello! This pull request adds Hubot notifications for deployments to Cloud Foundry.

![notification screenshot](https://cloud.githubusercontent.com/assets/86842/7050742/7ac26f0c-ddf1-11e4-9728-28e428deac6d.png)

TODOs (for now or later):
- [ ] Add tests
- [ ] Move auth/client stuff to a Cloud Foundry Node API client library (probably [`cloud-foundry`](https://github.com/ActiveState/cloud-foundry-client-js))
- [ ] After spending a few days on this (mostly trying to get auth working), I'm now realizing that this script actually has little to do with the others – move `notifications.coffee` to a `hubot-cf-notifications` plugin.
- [ ] Ignore `*-ssh` apps created by [cf-ssh](https://github.com/cloudfoundry-community/cf-ssh)

/cc @ozzyjohnson https://github.com/18F/18f-bot/pull/8
